### PR TITLE
Add option for inclusion of DBD source column to MultiDBD.get

### DIFF
--- a/dbdreader/dbdreader.py
+++ b/dbdreader/dbdreader.py
@@ -165,7 +165,7 @@ DBD_ERROR_INVALID_FILE_CRITERION_SPECIFIED = 11
 
 class DbdError(Exception):
     MissingCacheFileData = namedtuple('MissingCacheFileData', 'missing_cache_files cache_dir')
-    
+
     def __init__(self,value=9,mesg=None,data=None):
         self.value=value
         self.mesg=mesg
@@ -506,7 +506,7 @@ class DBDHeader(object):
         except KeyError:
             r = None
         return r
-
+    
     def read_header(self, fp, filename=''):
         ''' read the header of the file, given by fp '''
         fp.seek(0)

--- a/dbdreader/dbdreader.py
+++ b/dbdreader/dbdreader.py
@@ -165,7 +165,7 @@ DBD_ERROR_INVALID_FILE_CRITERION_SPECIFIED = 11
 
 class DbdError(Exception):
     MissingCacheFileData = namedtuple('MissingCacheFileData', 'missing_cache_files cache_dir')
-
+    
     def __init__(self,value=9,mesg=None,data=None):
         self.value=value
         self.mesg=mesg
@@ -1622,7 +1622,7 @@ class MultiDBD(object):
             if self.missions and mission_name not in self.missions:
                 filenames.remove(fn)
                 continue
-            # so we decided to keep the file.
+            # so we decided to keep the file. 
             if mission_name not in self.mission_list:
                 self.mission_list.append(mission_name)
             if self.isScienceDataFile(fn):
@@ -1635,7 +1635,7 @@ class MultiDBD(object):
         # We will raise an error when cache files are missing and when there are no files at all.
         if missing_cacheIDs:
             # craft some useful error message
-            mesg = f"\nOne or more cache files could not be found in {cacheDir}:\n"
+            mesg = f"\nOne or more cache files could not be found in {cacheDir}:\n" 
             for k, v in missing_cacheIDs.items():
                 mesg+=f"{k} reqd by {v[0]}"
                 if len(v)>1:

--- a/tests/dbdreader_test.py
+++ b/tests/dbdreader_test.py
@@ -271,6 +271,32 @@ class Dbdreader_MultiDBD_test(unittest.TestCase):
             data = e.data
             assert data.missing_cache_files['c4ec741e'][0] =="../data/unit_887-2021-321-3-0.tbd"
 
+    def test_include_source_data(self):
+        print("Verify that source DBDs correctly map to data points.")
+        multi = dbdreader.MultiDBD(pattern=self.pattern)
+
+        for parameter in multi.parameterNames["eng"] + multi.parameterNames["sci"]:
+            output = multi.get(parameter, include_source=True)
+            dbds = set(output[2])  # Unique source DBDs for this parameter
+            for dbd in dbds:
+                mask = output[2] == dbd
+                content = [output[0][mask], output[1][mask]]  # Only data attributed to this DBD
+                single = dbd.get(parameter)
+                # Data should be identical
+                assert all(content[0] == single[0])
+                assert all(content[1] == single[1])
+
+    def test_include_source_files(self):
+        print("Verify that all designated files are represented in sources.")
+        files = glob.glob(self.pattern)
+        multi = dbdreader.MultiDBD(pattern=self.pattern)
+
+        output = multi.get(*(multi.parameterNames["eng"] + multi.parameterNames["sci"]), include_source=True)
+
+        sources = {dbd.filename for parameter in output for dbd in parameter[2]}  # Unique source DBDs
+        # All files should be represented
+        assert all(file in sources for file in files)
+        assert all(source in files for source in sources)
         
     def get_method(self,method,fn,x,y):
         dbd=dbdreader.MultiDBD(pattern=fn)


### PR DESCRIPTION
This enables MultiDBD.get to return a third column with the underlying DBD objects that each data point is sourced from, which can be used for integrity checks.