### PR TITLE
Adds year to filename sorting

### DIFF
--- a/dbdreader/dbdreader.py
+++ b/dbdreader/dbdreader.py
@@ -256,7 +256,7 @@ class DBDList(list):
     *p : variable length list of str
         filenames
     '''
-    REGEX = re.compile(r"-[0-9]*-[0-9]*-[0-9]*\.[demnstDEMNST][bB][dD]")
+    REGEX = re.compile(r"-[0-9]*-[0-9]*-[0-9]*-[0-9]*\.[demnstDEMNST][bB][dD]")
     
     def __init__(self,*p):
         list.__init__(self,*p)
@@ -266,7 +266,7 @@ class DBDList(list):
         if match and len(match.group())>=13: # minimal format: -xxxx-x-x.yyy
             s, extension = os.path.splitext(match.group())
             number_fields = s.split("-")
-            n=sum([int(i)*10**j for i,j in zip(number_fields[1:],[5,3,0])]) # first field is '', so skip over
+            n=sum([int(i)*10**j for i,j in zip(number_fields[1:],[8,5,3,0])]) # first field is '', so skip over
             r = f"{key[:match.span()[0]]}-{n}{extension.lower()}"
         else:
             r = key.lower()


### PR DESCRIPTION
When using MultiDBD, files were being read in order:
- '*-10.dbd'
- '*-11.dbd'
- '*-12.dbd'
- '*-0.dbd'
- '*-1.dbd'
- '*-2.dbd'
- '*-3.dbd'
- etc.

This made for problems with MultiDBD.get_sync, as the times weren't monotonically increasing, so interpolation failed and every field returned nan. Adding the year to the regex and sort key fixed the problem.