### PR TITLE
Drops scipy dependency, uses numpy.interp

### DIFF
--- a/dbdreader/dbdreader.py
+++ b/dbdreader/dbdreader.py
@@ -4,7 +4,6 @@ import os
 import struct
 import time
 import numpy
-from scipy.interpolate import interp1d as si_interp1d
 import glob
 import sys
 import re
@@ -306,6 +305,32 @@ def heading_interpolating_function_factory(t, v):
     xi = partial(numpy.interp, xp=t, fp=x, left=numpy.nan, right=numpy.nan)
     yi = partial(numpy.interp, xp=t, fp=y, left=numpy.nan, right=numpy.nan)
     return lambda _t: numpy.arctan2(yi(_t), xi(_t)) % (2*numpy.pi)
+
+
+def _default_interp1d_factory(x, y):
+    '''Default linear interpolating function factory used by get_sync()
+    and get_CTD_sync().
+
+    Equivalent to scipy.interpolate.interp1d(x, y, bounds_error=False,
+    fill_value=numpy.nan), implemented with numpy.interp instead so that
+    dbdreader does not require scipy as a runtime dependency. Callers that
+    want other interpolation schemes (e.g. cubic splines) can still pass
+    their own interpolating_function_factory, importing scipy themselves
+    if needed.
+
+    numpy.interp requires x to be sorted (non-decreasing); scipy's interp1d
+    sorts internally by default (assume_sorted=False), so we do the same
+    here rather than assume the caller's x is already ordered.
+    '''
+    if len(x) < 2:
+        raise ValueError("Interpolation requires at least two data points.")
+    x = numpy.asarray(x)
+    y = numpy.asarray(y)
+    if numpy.any(numpy.diff(x) < 0):
+        idx = numpy.argsort(x)
+        x = x[idx]
+        y = y[idx]
+    return partial(numpy.interp, xp=x, fp=y, left=numpy.nan, right=numpy.nan)
 
 
 class DBDCache(object):
@@ -1631,7 +1656,7 @@ class MultiDBD(object):
         tv = self.get(*parameters, decimalLatLon=decimalLatLon, discardBadLatLon=discardBadLatLon,
                       return_nans=False)
         
-        default_interpolating_function_factory = partial(si_interp1d, bounds_error=False, fill_value=numpy.nan)
+        default_interpolating_function_factory = _default_interp1d_factory
         
         t = tv[0][0]
         r = []

--- a/dbdreader/dbdreader.py
+++ b/dbdreader/dbdreader.py
@@ -322,8 +322,8 @@ def _default_interp1d_factory(x, y):
     sorts internally by default (assume_sorted=False), so we do the same
     here rather than assume the caller's x is already ordered.
     '''
-    if len(x) < 2:
-        raise ValueError("Interpolation requires at least two data points.")
+    if len(x) < 1:
+        raise ValueError("Interpolation requires at least one data point.")
     x = numpy.asarray(x)
     y = numpy.asarray(y)
     if numpy.any(numpy.diff(x) < 0):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,17 +7,16 @@ requires-python = ">=3.10"
 authors = [
     {name = "Lucas Merckelbach", email = "lucas.merckelbach@hereon.de"}
 ]
-license = {text = "GPL-3.0"}
+license = {text = "GPL-3.0-or-later"}
 classifiers = [
     "Programming Language :: Python :: 3",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: POSIX",
 ]
 dependencies = [
     "lz4>=4.4.5",
     "numpy>=2.2.6",
-    "scipy>=1.15.3",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
-scipy
 pytest
 lz4
 


### PR DESCRIPTION
The only scipy call was interp1d(bounds_error=False, fill_value=nan) as the default linear interpolator in get_sync()/get_CTD_sync(). Replaced with numpy.interp (same nan-fill bounds behavior), matching the pattern already used for lat/lon interpolation elsewhere in the file. Sorts x/y internally when x isn't already non-decreasing, matching interp1d's assume_sorted=False default. Removes scipy from pyproject.toml and requirements.txt.

Callers can still supply their own interpolating_function_factory (e.g. scipy-based cubic splines); dbdreader itself no longer needs scipy at runtime. Motivated by the conda-forge recipe: scipy's floor was incompatible with dbdreader's python floor on cp310, and this removes the conflict at the source instead of dropping py3.10 support.